### PR TITLE
Proposal: add max points column to fish table

### DIFF
--- a/public/locales/cn/ocean-fishing.json
+++ b/public/locales/cn/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "Points",
     "doubleHook": "Double Hook",
     "tripleHook": "Triple Hook",
+    "maxPoints": "Max Points",
     "timeOfDay": "Time",
     "weather": "Weather",
     "category": "Category"

--- a/public/locales/de/ocean-fishing.json
+++ b/public/locales/de/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "Punkte",
     "doubleHook": "Doppelhaken",
     "tripleHook": "Tripelhaken",
+    "maxPoints": "Max Points",
     "timeOfDay": "Uhrzeit",
     "weather": "Wetter",
     "category": "Klasse"

--- a/public/locales/en/ocean-fishing.json
+++ b/public/locales/en/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "Points",
     "doubleHook": "Double Hook",
     "tripleHook": "Triple Hook",
+    "maxPoints": "Max Points",
     "timeOfDay": "Time",
     "weather": "Weather",
     "category": "Category"

--- a/public/locales/fr/ocean-fishing.json
+++ b/public/locales/fr/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "Points",
     "doubleHook": "Ferrage double",
     "tripleHook": "Ferrage triple",
+    "maxPoints": "Max Points",
     "timeOfDay": "Heure de la journée",
     "weather": "Météo",
     "category": "Catégorie"

--- a/public/locales/ja/ocean-fishing.json
+++ b/public/locales/ja/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "釣果点",
     "doubleHook": "ダブルフッキング",
     "tripleHook": "トリプルフッキング",
+    "maxPoints": "Max Points",
     "timeOfDay": "時間帯",
     "weather": "天候",
     "category": "種類"

--- a/public/locales/ko/ocean-fishing.json
+++ b/public/locales/ko/ocean-fishing.json
@@ -45,6 +45,7 @@
     "points": "Points",
     "doubleHook": "Double Hook",
     "tripleHook": "Triple Hook",
+    "maxPoints": "Max Points",
     "timeOfDay": "Time",
     "weather": "Weather",
     "category": "Category"

--- a/src/ocean-fishing/FishTable.tsx
+++ b/src/ocean-fishing/FishTable.tsx
@@ -98,6 +98,7 @@ const FishTable = ({ fishingSpots, time }: Props): React.ReactElement => {
                 </TableCell>
                 <TableCell align='center'>{t('fishInfo.points')}</TableCell>
                 <TableCell align='center'>{t('fishInfo.doubleHook')}</TableCell>
+                <TableCell align='center'>{t('fishInfo.maxPoints')}</TableCell>
                 <TableCell align='center'>{t(`fishInfo.${isSpectral ? 'timeOfDay' : 'weather'}`)}</TableCell>
                 <TableCell align='center'>{t('fishInfo.category')}</TableCell>
               </TableRow>
@@ -106,6 +107,24 @@ const FishTable = ({ fishingSpots, time }: Props): React.ReactElement => {
               {fishingSpot.fishes.map(fish => {
                 const spreadsheetData = fish.spreadsheetData
                 const isUnavailable = time !== undefined && spreadsheetData.time !== null && !spreadsheetData.time.includes(time)
+                let maxPoints: number | null = null
+
+                if (spreadsheetData.points !== null) {
+                  if (spreadsheetData.tripleHook !== null) {
+                    if (Array.isArray(spreadsheetData.tripleHook)) {
+                      maxPoints = spreadsheetData.tripleHook[1] * spreadsheetData.points
+                    } else {
+                      maxPoints = spreadsheetData.tripleHook * spreadsheetData.points
+                    }
+                  } else if (spreadsheetData.doubleHook !== null) {
+                    if (Array.isArray(spreadsheetData.doubleHook)) {
+                      maxPoints = spreadsheetData.doubleHook[1] * spreadsheetData.points
+                    } else {
+                      maxPoints = spreadsheetData.doubleHook * spreadsheetData.points
+                    }
+                  }
+                }
+
                 return (
                   <TableRow key={fish.id} hover sx={{
                     opacity: isUnavailable ? 0.5 : 1
@@ -169,6 +188,13 @@ const FishTable = ({ fishingSpots, time }: Props): React.ReactElement => {
                           {spreadsheetData.tripleHook !== null && (
                             <>&emsp;({formatDH(spreadsheetData.tripleHook)})</>
                           )}
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell align='center'>
+                      {maxPoints !== null && (
+                        <Typography>
+                          {maxPoints}
                         </Typography>
                       )}
                     </TableCell>


### PR DESCRIPTION
I threw together a max points column, which displays a simple calculation of double / triple hook count multiplied by points. I make this proposal because some lesser-point fish may appear less appealing when compared to others worth more. However, the multiples from double / triple hook often make the lesser-point fish a better target (and usually they're more common to hook too). An example of this is:

<img width="1037" alt="Screenshot 2022-05-02 at 10 36 08" src="https://user-images.githubusercontent.com/606627/166313679-48d4bb19-9121-477b-89c3-9cfd83013863.png">

I have added the English string of "Max Points" to all the translation files because I'm not sure how you usually translate the other strings. If you wish for me to define these via your preferred translation method, let me know what that is and I'll update them.

Finally I'd like to thank you for this tool and making my fishing journey to 3m points a whole lot easier than it would have been 🙏